### PR TITLE
Rename find-package(kodi) to Kodi and get addon.xml inline with other add-ons

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ macro(build_module module sources)
 endmacro()
 
 
-find_package(kodi REQUIRED)
+find_package(Kodi REQUIRED)
 
 find_package(OpenGL REQUIRED)
 find_package(Freetype REQUIRED)

--- a/src/addon.cpp
+++ b/src/addon.cpp
@@ -1,8 +1,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <kodi/xbmc_vis_dll.h>
-#include <kodi/xbmc_vis_types.h>
+#include <xbmc_vis_dll.h>
+#include <xbmc_vis_types.h>
 
 
 extern "C" 

--- a/visualization.hypnomix/addon.xml.in
+++ b/visualization.hypnomix/addon.xml.in
@@ -6,12 +6,11 @@
 	provider-name="amand.">
 	<extension
 		point="xbmc.player.musicviz"
-		library_linux="visualization.hypnomix.so"
-		library_osx="visualization.hypnomix.dylib" />
+		library_@PLATFORM@="@LIBRARY_FILENAME@"/>
 	<extension point="xbmc.addon.metadata">
 		<summary lang="en">Hypnomix visualization</summary>
 		<description lang="en">...</description>
 		<disclaimer lang="fr">...</disclaimer>
-		<platform>linux osx</platform>
+		<platform>@PLATFORM@</platform>
 	</extension>
 </addon>

--- a/visualization.hypnomix/addon.xml.in
+++ b/visualization.hypnomix/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon 
 	id="visualization.hypnomix"
-	version="0.1.0"
+	version="0.2.0"
 	name="Hypnomix"
 	provider-name="amand.">
 	<extension


### PR DESCRIPTION
Package renaming is need after https://github.com/xbmc/xbmc/pull/9750 goes in.
The rest is to bring xml files up to par and fix includes.
